### PR TITLE
11.0

### DIFF
--- a/models/hr_payroll.py
+++ b/models/hr_payroll.py
@@ -145,6 +145,9 @@ class HrPayslip(models.Model):
             logging.warn(dias_laborados)
             logging.warn(dias_ausentados_sumar)
             res.append({'name': 'Dias trabajados', 'sequence': 10,'code': 'TRABAJO100', 'number_of_days': (dias_laborados['days'] - dias_ausentados_restar), 'contract_id': contracts.id})
+        elif contracts.date_end and date_from <= contracts.date_end <= date_to:
+            dias_laborados = self.employee_id.get_work_days_data(Datetime.from_string(contracts.date_end), Datetime.from_string(date_to), calendar=contracts.resource_calendar_id)
+            res.append({'name': 'Dias trabajados', 'sequence': 10,'code': 'TRABAJO100', 'number_of_days': (dias_laborados['days'] - dias_ausentados_restar), 'contract_id': contracts.id})
         else:
             if contracts.schedule_pay == 'monthly':
                 res.append({'name': 'Dias trabajados','sequence': 10,'code': 'TRABAJO100','number_of_days': 30 - dias_ausentados_restar, 'contract_id': contracts.id})


### PR DESCRIPTION
En la linea 149 tenia dias_laborados['days'] + dias_ausentados_sumar en realidad dias_ausentados_sumar siempre esta vacia nunca almacena nada, en cambio  dias_ausentados_restar
almacena los dias que hay que restar (la funcion get_work_days_data no incluye las ausencias como lo hacia anteriormente en la funcion compute_sheet por eso se tiene que usar (dias_laborados['days'] - dias_ausentados_restar)