### PR TITLE
Error en historial de salario

### DIFF
--- a/models/hr_payroll.py
+++ b/models/hr_payroll.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 from odoo.release import version_info
 import logging
 import datetime
@@ -10,6 +10,7 @@ from dateutil.relativedelta import relativedelta
 from dateutil import relativedelta as rdelta
 from odoo.fields import Date, Datetime
 from odoo.addons.l10n_gt_extra import a_letras
+from odoo.exceptions import ValidationError
 
 class HrPayslip(models.Model):
     _inherit = 'hr.payslip'
@@ -92,6 +93,9 @@ class HrPayslip(models.Model):
         salario_promedio_total = 0
         if empleado_id.contract_ids[0].historial_salario_ids:
             for linea in empleado_id.contract_ids[0].historial_salario_ids:
+                if linea.fecha == False:
+                    raise ValidationError(_('Empleado debe de tener fecha en el historial de salario: ' + str(empleado_id.name)))
+
                 historial_salario.append({'salario': linea.salario, 'fecha':linea.fecha})
 
             historial_salario_ordenado = sorted(historial_salario, key=lambda k: k['fecha'],reverse=True)

--- a/models/rrhh.py
+++ b/models/rrhh.py
@@ -138,5 +138,5 @@ class rrhh_historial_salario(models.Model):
     _name = "rrhh.historial_salario"
 
     salario = fields.Float('Salario')
-    fecha = fields.Date('Fecha')
+    fecha = fields.Date('Fecha', required=True)
     contrato_id = fields.Many2one('hr.contract','Contato')

--- a/models/rrhh.py
+++ b/models/rrhh.py
@@ -137,6 +137,6 @@ class rrhh_prestamo_linea(models.Model):
 class rrhh_historial_salario(models.Model):
     _name = "rrhh.historial_salario"
 
-    salario = fields.Float('Salario')
+    salario = fields.Float('Salario',required=True)
     fecha = fields.Date('Fecha', required=True)
     contrato_id = fields.Many2one('hr.contract','Contato')

--- a/models/rrhh.py
+++ b/models/rrhh.py
@@ -137,6 +137,6 @@ class rrhh_prestamo_linea(models.Model):
 class rrhh_historial_salario(models.Model):
     _name = "rrhh.historial_salario"
 
-    salario = fields.Float('Salario',required=True)
+    salario = fields.Float('Salario', required=True)
     fecha = fields.Date('Fecha', required=True)
     contrato_id = fields.Many2one('hr.contract','Contato')


### PR DESCRIPTION
ticket:
https://aquih.odoo.com/web#active_id=12778&cids=1&id=12778&model=helpdesk.ticket&menu_id=

Desplegaba un error por que en algunos casos en el historial de salarios agregaban un salario sin fecha, y al convertir la fecha daba error por que llega vacio, entonces ahora mostramos un mensaje con el nombre del empleado para que identifiquen cual es el problema.

![1](https://user-images.githubusercontent.com/8306339/149633411-f3f1f912-cd77-4554-be8f-8b8237901335.jpg)
